### PR TITLE
Fixed manual installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ Installing from git repository:
 
 ```bash
 $ cd ~ # use $HOME
-$ git clone https://github.com/fakefred/memethesis-cli # clone the git repo
-$ cd memethesis-cli # go into directory
+$ git clone https://github.com/fakefred/memethesis-cli # will clone the git repo
+$ cd memethesis-cli # will go into directory
 $ python3 setup.py bdist_wheel  # will generate .whl
-$ pip3 install dist/memethesis*
+$ pip3 install dist/memethesis* # will install the newly-created memethesis.whl created above
 ```
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -53,8 +53,11 @@ $ pip install memethesis==<latest_version> --upgrade
 Installing from git repository:
 
 ```bash
-$ python setup.py bdist_wheel  # will generate .whl
-$ pip install dist/memethesis-[something].whl
+$ cd ~ # use $HOME
+$ git clone https://github.com/fakefred/memethesis-cli # clone the git repo
+$ cd memethesis-cli # go into directory
+$ python3 setup.py bdist_wheel  # will generate .whl
+$ pip3 install dist/memethesis*
 ```
 
 ### Usage


### PR DESCRIPTION
Fixed manual installation instructions when manually downloading and compiling `memethesis-cli` ourselves: use python3 instead of python since most users don't have only one python version installed (for example I have 3 versions of python: python, python2.7 and python2.7); instead of having "[something]", we have the POSIX-compliant asterisk `*`, which lets us choose all files.